### PR TITLE
[SPARK-31710][SQL]Add compatibility flag to cast long to timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2576,6 +2576,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+    val LONG_TIMESTAMP_CONVERSION_IN_SECONDS =
+    buildConf("spark.sql.legacy.longTimestampConversionInSeconds")
+      .internal()
+      .doc("When false, Byte/Short/Int/Long value is interpreted as milliseconds " +
+        "during the timestamp conversion ." +
+        "when true, the value will be  interpreted as seconds " +
+        "to be consistent with decimal/double. ")
+      .booleanConf
+      .createWithDefault(true)
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -3160,6 +3169,9 @@ class SQLConf extends Serializable with Logging {
   def parquetRebaseDateTimeInReadEnabled: Boolean = {
     getConf(SQLConf.LEGACY_PARQUET_REBASE_DATETIME_IN_READ)
   }
+  
+  def longTimestampConversionInSeconds: Boolean = getConf(LONG_TIMESTAMP_CONVERSION_IN_SECONDS)
+
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
As we know,long datatype is interpreted as milliseconds when conversion to timestamp in hive, while long is interpreted as seconds when conversion to timestamp  in spark, we have been facing error data during migrating hive sql to spark sql. with  compatibility flag we can fix this error,


### Why are the changes needed?
we have many sqls runing in product, so we need  a compatibility flag to make them migrating smoothly ,meanwhile do not change the user behavior in spark.


### Does this PR introduce any user-facing change?
if user use this patch ,then user should set this paramter ,
if not, user do not need to do anything.


### How was this patch tested?
unit test added
