### PR TITLE
[SPARK-31710][SQL]Add compatibility flag to cast long to timestamp

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -455,13 +455,9 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
 
   // SPARK-31710 converting seconds to us,Add compatibility flag
   private[this] def longToTimestamp(t: Long): Long = {
-    if ( SQLConf.get.getConf( SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS ) )
-    (t * MICROS_PER_SECOND).toLong
-    else
-    (t * MICROS_PER_MILLI).toLong
+    if ( SQLConf.get.getConf( SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS )) t * 1000000L
+    else t * 1000L
   }
-  
-  private[this] def longToTimestamp(t: Long): Long = SECONDS.toMicros(t)
   // converting us to seconds
   private[this] def timestampToLong(ts: Long): Long = {
     Math.floorDiv(ts, MICROS_PER_SECOND)
@@ -1287,10 +1283,8 @@ abstract class CastBase extends UnaryExpression with TimeZoneAwareExpression wit
   
    // SPARK-31710 converting seconds to us,Add compatibility flag
   private[this] def longToTimeStampCode(l: ExprValue): Block = {
-  if ( SQLConf.get.getConf( SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS ) )
-  code"$l * (long)$MICROS_PER_SECOND"
-  else
-  code"$l * (long)$MICROS_PER_MILLI"
+    if (SQLConf.get.getConf(SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS)) code"$l * 1000000L"
+    else code"$l * 1000L"
   }
   
   private[this] def timestampToLongCode(ts: ExprValue): Block =


### PR DESCRIPTION
What changes were proposed in this pull request?
As we know,long datatype is interpreted as milliseconds when conversion to timestamp in hive, while long is interpreted as seconds when conversion to timestamp in spark, we have been facing error data during migrating hive sql to spark sql. with compatibility flag we can fix this error,

Why are the changes needed?
we have many sqls runing in product, so we need a compatibility flag to make them migrating smoothly ,meanwhile do not change the user behavior in spark.

Does this PR introduce any user-facing change?
if user use this patch ,then user should set this paramter ,
if not, user do not need to do anything.

How was this patch tested?
unit test added