### PR TITLE
Add compatibility flag to cast long to timestamp

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuite.scala
@@ -1004,4 +1004,32 @@ class CastSuite extends SparkFunSuite with ExpressionEvalHelper {
       checkEvaluation(ret, InternalRow(null))
     }
   }
+  test("SPARK-31710:Add compatibility flag to cast long to timestamp") {
+    withSQLConf(
+      SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS.key -> "false") {
+      for (tz <- ALL_TIMEZONES) {
+        def checkLongToTimestamp(str: Long, expected: Long): Unit = {
+          checkEvaluation(cast(str, TimestampType, Option(tz.getID)), expected)
+        }
+        checkLongToTimestamp(253402272000L, 253402272000000L)
+        checkLongToTimestamp(-5L, -5000L)
+        checkLongToTimestamp(1L, 1000L)
+        checkLongToTimestamp(0L, 0L)
+        checkLongToTimestamp(123L, 123000L)
+      }
+    }
+    withSQLConf(
+      SQLConf.LONG_TIMESTAMP_CONVERSION_IN_SECONDS.key -> "true") {
+      for (tz <- ALL_TIMEZONES) {
+        def checkLongToTimestamp(str: Long, expected: Long): Unit = {
+          checkEvaluation(cast(str, TimestampType, Option(tz.toZoneId.getId)), expected)
+        }
+        checkLongToTimestamp(253402272000L, 253402272000000000L)
+        checkLongToTimestamp(-5L, -5000000L)
+        checkLongToTimestamp(1L, 1000000L)
+        checkLongToTimestamp(0L, 0L)
+        checkLongToTimestamp(123L, 123000000L)
+      }
+    }
+  }
 }


### PR DESCRIPTION
What changes were proposed in this pull request?
As we know,long datatype is interpreted as milliseconds when conversion to timestamp in hive, while long is interpreted as seconds when conversion to timestamp in spark, we have been facing error data during migrating hive sql to spark sql. with compatibility flag we can fix this error,

Why are the changes needed?
we have many sqls runing in product, so we need a compatibility flag to make them migrating smoothly ,meanwhile do not change the user behavior in spark.

Does this PR introduce any user-facing change?
if user use this patch ,then user should set this paramter ,
if not, user do not need to do anything.

How was this patch tested?
unit test added